### PR TITLE
Fixes #7: Append .savefold extension to attribute file paths

### DIFF
--- a/savefold-utils.el
+++ b/savefold-utils.el
@@ -39,8 +39,14 @@ This naively replaces path slashes with ! (/a/b/c -> !a!b!c) leading to a chance
 of collision."
   (let* ((fpath (expand-file-name fpath))
          (fpath (string-replace "/" "!" fpath))
-         (fpath (string-replace ":" "!" fpath)))  ; For windows
-    (expand-file-name fpath savefold-directory)))
+         (fpath (string-replace ":" "!" fpath))  ; For windows
+         (old-fpath (expand-file-name fpath savefold-directory))
+         (new-fpath (expand-file-name (concat fpath ".savefold")
+                                      savefold-directory)))
+    (if (and (file-exists-p old-fpath)
+             (not (file-exists-p new-fpath)))
+        old-fpath
+      new-fpath)))
 
 (defun savefold-utils--get-file-attr-table (fpath)
   "Get the attribute hash table for file FPATH.


### PR DESCRIPTION
Append the .savefold extension to the flattened path returned by savefold-utils--get-attr-table-fpath to fix #7.

Appending .savefold ensures the cache file uses a neutral extension that does not trigger hooks, such as interactive compression or encryption.

To maintain backward compatibility with existing setups, the function checks if an unextended legacy cache file exists. If found, and no new cache file has been written yet, it falls back to the old path so user data is preserved transparently.
